### PR TITLE
Add link to WSL forum site

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Issues may be closed by the original poster at any time.  We will close issues i
 - WSL Blog: https://blogs.msdn.microsoft.com/wsl
 - Console Blog: https://blogs.msdn.microsoft.com/commandline/
 - Community powered list of programs that work and don't work: https://github.com/ethanhs/WSL-Programs
+- Community powered discussion forum: http://wsl-forum.qztc.io/


### PR DESCRIPTION
This isn't really an Issue; I figured a Pull Request was the closest analogy:

This bug-tracker started off as mostly bugs.  It's slowly gaining more confused users as WSL's story becomes more complex / flushed out to more smaller edge cases, and as WSL is adopted more broadly.

I'm having trouble keeping the two uses straight; it sounds like at least a couple other posters are too.

My understanding is that Microsoft doesn't plan to launch a forum until maybe after the Anniversary release?  My instinct is that initial users of that release will go search for stuff and will rapidly fill this forum, making it much harder to track actual bugs, unless somewhere better is available.

So, here, have a forum!  Yay Internet!

I don't want to step on the toes of the WSL team, though.  Let me know if this would interfere with what y'all are trying to do.