### PR TITLE
Fix contributing link in the issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -12,4 +12,4 @@ If you have a feature request, please post to [the UserVoice](https://wpdev.user
 * Strace of the failing command, if applicable:  (If `<cmd>` is failing, then run `strace -o strace.txt -ff <cmd>`, and post the strace.txt output here)
 
 
-See [our contributing instructions](/CONTRIBUTING.md) for assistance.
+See [our contributing instructions](https://github.com/Microsoft/BashOnWindows/blob/master/CONTRIBUTING.md) for assistance.


### PR DESCRIPTION
Hi,

this Pull Request just fixed the link to the contributing instructions in the `ISSUE_TEMPLATE.md`.

Currently it points to: https://github.com/CONTRIBUTING.md on the issue submission form.

Please note that this issue only shows up in the issue submission form. The normal view in the repo works good before and after the path.

See here:
![image](https://user-images.githubusercontent.com/2596554/27557766-0444f360-5abb-11e7-82dd-d278f5ad58e5.png)
