### PR TITLE
Simplify copying and pasting commands from CONTRIBUTING.md into cmd.exe; etc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,23 +98,17 @@ Some bugs will require more detailed logs to help determine the cause.  There is
 #### Starting logging
 
 ```
-
-C:\> logman.exe create trace lxcore_kernel -p {0CD1C309-0878-4515-83DB-749843B3F5C9} -mode 0x00000008 -ft 10:00 -o .\lxcore_kernel.etl -ets 
-logman create trace lxcore_adss -p {754E4536-6735-4194-BE81-1374BD2E9B0D} -ft 1:00 -rt -o .\lxcore_adss.etl -ets 
-logman create trace lxcore_user -p {D90B9468-67F0-5B3B-42CC-82AC81FFD960} -ft 1:00 -rt -o .\lxcore_user.etl -ets 
-logman create trace lxcore_service -p {B99CDB5A-039C-5046-E672-1A0DE0A40211} -ft 1:00 -rt -o .\lxcore_service.etl -ets 
-
+logman.exe create trace lxcore_kernel -p {0CD1C309-0878-4515-83DB-749843B3F5C9} -mode 0x00000008 -ft 10:00 -o .\lxcore_kernel.etl -ets 
+logman.exe create trace lxcore_user -p {D90B9468-67F0-5B3B-42CC-82AC81FFD960} -ft 1:00 -rt -o .\lxcore_user.etl -ets 
+logman.exe create trace lxcore_service -p {B99CDB5A-039C-5046-E672-1A0DE0A40211} -ft 1:00 -rt -o .\lxcore_service.etl -ets 
 ```
 
 #### Stopping logging
 
 ```
-
-C:\> logman stop lxcore_kernel -ets
-logman stop lxcore_adss -ets
-logman stop lxcore_user -ets
-logman stop lxcore_service -ets
-
+logman.exe stop lxcore_kernel -ets
+logman.exe stop lxcore_user -ets
+logman.exe stop lxcore_service -ets
 ```
 
 #### Generated files
@@ -122,7 +116,6 @@ logman stop lxcore_service -ets
 The files generated will be in the directory where the above commands ran.  The files will be named:
 
 ```
-lxcore_adss.etl
 lxcore_kernel.etl
 lxcore_service.etl
 lxcore_user.etl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ $ strace -ff -o <outputfile> <command>
 ### 8) Detailed Logs
 Some bugs will require more detailed logs to help determine the cause.  There is a CMD command to start detailed logging and another to stop.  The logs are generated locally into the working directory.
 
-#### Starting logging
+#### Start collecting logs
 
 ```
 logman.exe create trace lxcore_kernel -p {0CD1C309-0878-4515-83DB-749843B3F5C9} -mode 0x00000008 -ft 10:00 -o .\lxcore_kernel.etl -ets 
@@ -103,7 +103,7 @@ logman.exe create trace lxcore_user -p {D90B9468-67F0-5B3B-42CC-82AC81FFD960} -f
 logman.exe create trace lxcore_service -p {B99CDB5A-039C-5046-E672-1A0DE0A40211} -ft 1:00 -rt -o .\lxcore_service.etl -ets 
 ```
 
-#### Stopping logging
+#### Stop collecting logs
 
 ```
 logman.exe stop lxcore_kernel -ets
@@ -111,7 +111,7 @@ logman.exe stop lxcore_user -ets
 logman.exe stop lxcore_service -ets
 ```
 
-#### Generated files
+#### Generated log files
 
 The files generated will be in the directory where the above commands ran.  The files will be named:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ A title succinctly describing the issue.
 Your Windows build number.  This can be gathered from the CMD prompt using the `ver` command.
 
 ```
-C:\>ver 
+C:\> ver 
 Microsoft Windows [Version 10.0.14385] 
 ``` 
 
@@ -36,15 +36,14 @@ Should include all packages and environmental variables as well as other require
 
 #### Example:
 
-`$ sudo apt-get install traceroute`
-`$ traceroute www.microsoft.com`
+`$ sudo apt-get install traceroute && traceroute www.microsoft.com`
 
 ### 4) Copy of the terminal output
 
 #### Example:
 
 ```
-russ@RUSSALEX-BOOK:/mnt/c$ traceroute www.microsoft.com
+$ traceroute www.microsoft.com
 traceroute to www.microsoft.com (23.75.239.28), 30 hops max, 60 byte packets
 setsockopt IP_MTU_DISCOVER: Invalid argument
 ```
@@ -66,7 +65,7 @@ Strace can produce a very long output.  If this is more than about 20 lines plea
 #### Example:
 
 ```
-russ@RUSSALEX-BOOK:/mnt/c$ strace traceroute www.microsoft.com
+$ strace traceroute www.microsoft.com
 execve("/usr/bin/traceroute", ["traceroute", "www.microsoft.com"], [/* 22 vars */]) = 0
 brk(0)                                  = 0x7fffdd3bc000
 access("/etc/ld.so.nohwcap", F_OK)      = -1 ENOENT (No such file or directory)
@@ -96,29 +95,33 @@ $ strace -ff -o <outputfile> <command>
 ### 8) Detailed Logs
 Some bugs will require more detailed logs to help determine the cause.  There is a CMD command to start detailed logging and another to stop.  The logs are generated locally into the working directory.
 
-#### Start
+#### Starting logging
 
-``` 
->logman.exe create trace lxcore_kernel -p {0CD1C309-0878-4515-83DB-749843B3F5C9} -mode 0x00000008 -ft 10:00 -o .\lxcore_kernel.etl -ets 
->logman create trace lxcore_adss -p {754E4536-6735-4194-BE81-1374BD2E9B0D} -ft 1:00 -rt -o .\lxcore_adss.etl -ets 
->logman create trace lxcore_user -p {D90B9468-67F0-5B3B-42CC-82AC81FFD960} -ft 1:00 -rt -o .\lxcore_user.etl -ets 
->logman create trace lxcore_service -p {B99CDB5A-039C-5046-E672-1A0DE0A40211} -ft 1:00 -rt -o .\lxcore_service.etl -ets 
-``` 
+```
 
-#### Stop 
+C:\> logman.exe create trace lxcore_kernel -p {0CD1C309-0878-4515-83DB-749843B3F5C9} -mode 0x00000008 -ft 10:00 -o .\lxcore_kernel.etl -ets 
+logman create trace lxcore_adss -p {754E4536-6735-4194-BE81-1374BD2E9B0D} -ft 1:00 -rt -o .\lxcore_adss.etl -ets 
+logman create trace lxcore_user -p {D90B9468-67F0-5B3B-42CC-82AC81FFD960} -ft 1:00 -rt -o .\lxcore_user.etl -ets 
+logman create trace lxcore_service -p {B99CDB5A-039C-5046-E672-1A0DE0A40211} -ft 1:00 -rt -o .\lxcore_service.etl -ets 
 
-``` 
->logman stop lxcore_kernel -ets
->logman stop lxcore_adss -ets
->logman stop lxcore_user -ets
->logman stop lxcore_service -ets
-``` 
+```
 
-#### Output
+#### Stopping logging
 
-Files generated are in the directory where the commands above ran:
+```
 
-```          
+C:\> logman stop lxcore_kernel -ets
+logman stop lxcore_adss -ets
+logman stop lxcore_user -ets
+logman stop lxcore_service -ets
+
+```
+
+#### Generated files
+
+The files generated will be in the directory where the above commands ran.  The files will be named:
+
+```
 lxcore_adss.etl
 lxcore_kernel.etl
 lxcore_service.etl


### PR DESCRIPTION
A)

This documentation patch makes it easier for users to copy and paste your suggested commands into a console window.

(Yes, the trailing carriage returns are important.  For a set of four commands to run automatically, the user must include a trailing carriage return on the clipboard before clicking "Paste".)

B)

The patch also makes the main text of the file slightly easier to read and understand.